### PR TITLE
fix(schema): support import syntax upon codegen

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -7,6 +7,7 @@ import * as path from 'path'
 import { PrismaGenerator } from './PrismaGenerator'
 import { PrismaTypescriptGenerator } from './PrismaTypescriptGenerator'
 import { buildSchema, printSchema } from 'graphql'
+import { importSchema } from 'graphql-import'
 
 const argv = yargs
   .usage(`Usage: $0 -i [input] -g [generator] -b [outputBinding]`)
@@ -70,7 +71,7 @@ async function run(argv) {
 
 function getSchemaFromInput(input) {
   if (input.endsWith('.graphql') || input.endsWith('.gql')) {
-    return buildSchema(fs.readFileSync(input, 'utf-8'))
+    return buildSchema(importSchema(input))
   }
 
   if (input.endsWith('.js') || input.endsWith('.ts')) {


### PR DESCRIPTION
With 2.0, related .graphql files are not imported into the schema when we
run `graphql codegen`. It is due to the fact that bin.ts is just reading the schema literally right now. i.e. in line 73
https://github.com/prismagraphql/prisma-binding/blob/ef7fc575a8a5473db2f48574c488c71ca181bf9f/src/bin.ts#L71-L86

fix: #168